### PR TITLE
Bump jackson dependencies to 2.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
         <log4j.version>2.17.1</log4j.version>
         <guava.version>31.1-jre</guava.version>
         <oci-java-sdk-version>2.14.1</oci-java-sdk-version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <cc.code-coverage-ratio>0.2</cc.code-coverage-ratio>
         <junit-jupiter-version>5.5.0</junit-jupiter-version>
         <management-plane-version>0.2.143</management-plane-version>
         <jersey-version>2.25.1</jersey-version>
-        <jackson-version>2.12.5</jackson-version>
+        <jackson-version>2.14.1</jackson-version>
 	<slf4j.version>1.7.21</slf4j.version>
     </properties>
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Bumping to latest jackson version. Resolving https://github.com/opensearch-project/opensearch-oci-object-storage/security/dependabot/12.

### Issues Resolved
dependabot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
