### PR TITLE
Fix indentation in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <management-plane-version>0.2.143</management-plane-version>
         <jersey-version>2.25.1</jersey-version>
         <jackson-version>2.14.1</jackson-version>
-	<slf4j.version>1.7.21</slf4j.version>
+        <slf4j.version>1.7.21</slf4j.version>
     </properties>
 
     <modules>
@@ -28,15 +28,15 @@
         <module>oci-repository-plugin</module>
     </modules>
     <dependencyManagement>
-      <dependencies>
+        <dependencies>
 
-	    <!-- Required so that we can get logging from OCI SDK  -->
-	    <dependency>
+            <!-- Required so that we can get logging from OCI SDK  -->
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-	    
+
             <!-- Cross project dependencies-->
             <dependency>
                 <groupId>com.oracle.pic.opensearch</groupId>


### PR DESCRIPTION
No changes other than standardizing the indentation to 4 spaces throughout the pom.xml file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
