### PR TITLE
Update lombok to 1.18.26

### DIFF
--- a/oci-repository-plugin/pom.xml
+++ b/oci-repository-plugin/pom.xml
@@ -72,7 +72,7 @@
       <dependency>
           <groupId>org.projectlombok</groupId>
           <artifactId>lombok</artifactId>
-          <version>1.18.16</version>
+          <version>1.18.26</version>
       </dependency>
 
       <!-- provided scoped deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.16</version>
+                <version>1.18.26</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This project is currently targeting Java 15 bytecode. Since Java 15 is EOL I tried to build with Java 17, but that needed the newer version of lombok to work correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
