### PR TITLE
upgrade opensearch version to 1.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install the plugin on your OpenSearch cluster
 ```bash
 OPENSEARCH_HOME=<YOUR OPENSEARCH INSTALLATION PATH HERE> # (e.g. /Users/saherman/opensearch)
 
-${OPENSEARCH_HOME}/bin/opensearch-plugin install file://target/releases/oci_repository_plugin-1.2.4.zip
+${OPENSEARCH_HOME}/bin/opensearch-plugin install file://target/releases/oci_repository_plugin-1.3.8.zip
 ```
 
 Start your cluster.

--- a/oci-repository-plugin/src/main/resources/plugin-descriptor.properties
+++ b/oci-repository-plugin/src/main/resources/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=The OCI repository plugin adds OCI Object Storage support for repositories.
 #
 # 'version': plugin's version
-version=1.2.4
+version=1.3.8
 #
 # 'name': the plugin name
 name=repository-oci
@@ -22,4 +22,4 @@ java.version=1.8
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-opensearch.version=1.2.4
+opensearch.version=1.3.8

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
     <name>OCI OpenSearch plugins POM</name>
     <properties>
-        <opensearch.version>1.2.4</opensearch.version>
+        <opensearch.version>1.3.8</opensearch.version>
         <log4j.version>2.17.1</log4j.version>
         <guava.version>31.1-jre</guava.version>
         <oci-java-sdk-version>2.14.1</oci-java-sdk-version>


### PR DESCRIPTION
### Description
We upgrade the opensearch version of OCI Object Storage repo from 1.2.4 to 1.3.8 to deal with security concerns for the repo (6 CVEs). 

### Issues Resolved
Resolves #31 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
