### PR TITLE
fix transient dependencies resolution and add external integration tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:
-        arguments: clean test assemble
+        arguments: clean build

--- a/build.gradle
+++ b/build.gradle
@@ -38,18 +38,44 @@ subprojects {
         maven { url "https://plugins.gradle.org/m2/" }
     }
 
+    configurations.runtimeClasspath {
+        exclude group: 'javax.annotation', module: 'javax.annotation-api'
+    }
+
     dependencies {
-        implementation gradleApi()
-        implementation localGroovy()
         implementation "net.jodah:failsafe:2.4.0"
         implementation "com.google.guava:guava:31.1-jre"
         implementation "org.apache.commons:commons-lang3:3.9"
         implementation "commons-io:commons-io:2.7"
+        /******************** Hacking transient dependencies for OCI SDK ********************/
+        // TODO: For some odd reason it seems that the OpenSearch gradle plugin overrides resolution of implementation
+        // configuration which is why this hack is needed so we can get the transient dependencies packaged properly
+
+
+        implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
+        compileClasspath("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
+        testCompileClasspath("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
+        runtimeClasspath("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
+        testRuntimeClasspath("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
+
         implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage-generated:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage-extensions:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-common:${sdk_version}")
+        compileClasspath("com.oracle.oci.sdk:oci-java-sdk-objectstorage:${sdk_version}")
+        testCompileClasspath("com.oracle.oci.sdk:oci-java-sdk-objectstorage:${sdk_version}")
+        runtimeClasspath("com.oracle.oci.sdk:oci-java-sdk-objectstorage:${sdk_version}")
+        testRuntimeClasspath("com.oracle.oci.sdk:oci-java-sdk-objectstorage:${sdk_version}")
+
+        runtimeClasspath("org.slf4j:slf4j-api") {
+            version {
+                strictly "1.7.33"
+            }
+        }
+        testRuntimeClasspath("org.slf4j:slf4j-api") {
+            version {
+                strictly "1.7.33"
+            }
+        }
+        /******************************* End of transient dependency hack for OCI SDK*****************************************/
+
         implementation("com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${jackson_version}")
         implementation("com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:${jackson_version}")
         implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jackson_version}")

--- a/oci-objectstorage-fixture/build.gradle
+++ b/oci-objectstorage-fixture/build.gradle
@@ -8,8 +8,6 @@ apply plugin: 'java'
 apply plugin: 'java-library'
 
 dependencies {
-    implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
-    implementation('jakarta.ws.rs:jakarta.ws.rs-api:2.1.6')
     testImplementation 'junit:junit:4.13.2'
     implementation("org.opensearch:opensearch:${opensearch_version}")
 }

--- a/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/NonJerseyServer.java
+++ b/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/NonJerseyServer.java
@@ -10,15 +10,21 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class NonJerseyServer implements Closeable {
-    public static final String BASE_URI = "http://localhost:8080/";
-    private static int PORT = 8080;
-    private static String URL = "localhost";
+    public static final String DEFAULT_BASE_URI = "http://localhost:8080/";
+    private final static int DEFAULT_PORT = 8080;
+    private final static String URL = "localhost";
     private final HttpServer server;
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final int port;
 
     public NonJerseyServer() throws IOException {
-        this.server = HttpServer.create(new InetSocketAddress(InetAddress.getByName(URL), PORT), 0);
+        this(DEFAULT_PORT);
+    }
+
+    public NonJerseyServer(int port) throws IOException {
+        this.server = HttpServer.create(new InetSocketAddress(InetAddress.getByName(URL), port), 0);
         this.server.createContext("/", new OciHttpHandler());
+        this.port = port;
     }
 
     public void start() {
@@ -37,5 +43,9 @@ public class NonJerseyServer implements Closeable {
     public void close() throws IOException {
         server.stop(0);
         executorService.shutdownNow();
+    }
+
+    public String getUrl() {
+        return String.format("http://localhost:%s/", port);
     }
 }

--- a/oci-objectstorage-fixture/src/test/java/org/opensearch/fixtures/oci/FixtureTests.java
+++ b/oci-objectstorage-fixture/src/test/java/org/opensearch/fixtures/oci/FixtureTests.java
@@ -66,7 +66,7 @@ public class FixtureTests {
         // create the client
         Client c = ClientBuilder.newClient();
 
-        target = c.target(NonJerseyServer.BASE_URI);
+        target = c.target(NonJerseyServer.DEFAULT_BASE_URI);
         objectStorage =
                 ObjectStorageClient.builder()
                         .endpoint("http://localhost:8080")

--- a/oci-repository-plugin/build.gradle
+++ b/oci-repository-plugin/build.gradle
@@ -3,7 +3,6 @@ import org.opensearch.gradle.test.RestIntegTestTask
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
-apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: "io.freefair.lombok"
 apply plugin: 'jacoco'
@@ -61,6 +60,11 @@ loggerUsageCheck.enabled = false
 // No need to validate pom, as we do not upload to maven/sonatype
 validateNebulaPom.enabled = false
 
+forbiddenApis.ignoreFailures = true
+forbiddenApisTest.ignoreFailures = true
+dependencyLicenses.enabled = false
+testingConventions.enabled = false
+thirdPartyAudit.enabled = false
 
 buildscript {
     repositories {
@@ -75,8 +79,6 @@ buildscript {
     }
 }
 configurations.testImplementation {
-    exclude group: 'commons-logging', module: 'commons-logging'
-    exclude group: 'com.google.code.findbugs', module: 'jsr305'
     exclude group: 'javax.annotation', module: 'javax.annotation-api'
 }
 
@@ -87,7 +89,6 @@ dependencies {
     }
     testImplementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}")
     testImplementation("org.opensearch.test:framework:${opensearch_version}")
-
     testImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
 }
 
@@ -107,6 +108,11 @@ task integTest(type: RestIntegTestTask) {
 tasks.named("check").configure { dependsOn(integTest) }
 
 integTest {
+    systemProperty "java.security.policy", "file://${projectDir}/src/main/resources/plugin-security.policy"
+    testLogging.showStandardStreams = true
+
+    include '**/*IT.class'
+
     // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
     if (System.getProperty("test.debug") != null) {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
@@ -115,6 +121,7 @@ integTest {
 
 testClusters.integTest {
     testDistribution = "INTEG_TEST"
+    systemProperty "java.security.policy", "file://${projectDir}/src/main/resources/plugin-security.policy"
 
     // This installs our plugin into the testClusters
     plugin(project.tasks.bundlePlugin.archiveFile)

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
@@ -190,7 +190,7 @@ class OciObjectStorageBlobStore implements BlobStore {
                                 public void onError(GetBucketRequest getBucketRequest, Throwable error) {
                                     log.error("failure getting bucket: {} with namespace: {}", bucketName, namespace, error);
                                 }
-                            }).get(10, TimeUnit.SECONDS);
+                            }).get();
 
             return getBucketResponse.getBucket() != null;
         } catch (final Exception e) {

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageClientSettings.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageClientSettings.java
@@ -148,39 +148,11 @@ public class OciObjectStorageClientSettings {
     }
 
     private static BasicAuthenticationDetailsProvider toAuthDetailsProvider() {
-
-        /*
-         * Work around security bug while using Instance Principal Authentication
-         * where adding the required java.net.SocketPermission to oci-repository-plugin/src/main/resources/plugin-security.policy
-         * doesn't fix the issue. See https://github.com/opensearch-project/opensearch-oci-object-storage/issues/13
-         */
-        SecurityManager sm = System.getSecurityManager();
-
         try {
-
-            AccessController.doPrivileged(
-                    (PrivilegedAction<Object>)
-                            () -> {
-                                System.setSecurityManager(
-                                        new SecurityManager() {
-
-                                            @Override
-                                            public void checkPermission(Permission perm) {
-                                                if (perm instanceof AllPermission) {
-                                                    throw new SecurityException();
-                                                }
-                                            }
-                                        });
-                                return null;
-                            });
-
             return InstancePrincipalsAuthenticationDetailsProvider.builder().build();
-
         } catch (Exception ex) {
             log.error("Failure calling toAuthDetailsProvider", ex);
             throw ex;
-        } finally {
-            System.setSecurityManager(sm);
         }
     }
 }

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageRepository.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageRepository.java
@@ -42,7 +42,7 @@ public class OciObjectStorageRepository extends BlobStoreRepository {
     static final ByteSizeValue MIN_CHUNK_SIZE = new ByteSizeValue(1, ByteSizeUnit.BYTES);
     static final ByteSizeValue MAX_CHUNK_SIZE = new ByteSizeValue(100, ByteSizeUnit.MB);
 
-    static final String TYPE = "oci";
+    public static final String TYPE = "oci";
 
     public static final Setting<String> BUCKET_SETTING =
             simpleString("bucket", Property.NodeScope, Property.Dynamic);

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
@@ -112,12 +112,8 @@ public class OciObjectStorageService implements Closeable {
                 SocketAccess.doPrivilegedIOException(
                         () ->
                                 ObjectStorageAsyncClient.builder()
-                                        .configuration(ClientConfiguration.builder()
-                                                //.connectionTimeoutMillis(10000)
-                                                //.readTimeoutMillis(10000)
-                                                .build()
-                                        ).build(
-                                                clientSettings.getAuthenticationDetailsProvider()));
+                                        .configuration(ClientConfiguration.builder().build())
+                                        .build(clientSettings.getAuthenticationDetailsProvider()));
 
         objectStorageClient.setEndpoint(clientSettings.getEndpoint());
 

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginIT.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginIT.java
@@ -1,0 +1,306 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.repositories.oci;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
+import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.client.Node;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.indices.CreateIndexRequest;
+import org.opensearch.cluster.health.ClusterHealthStatus;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.fixtures.oci.NonJerseyServer;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest.ALL_SNAPSHOTS;
+
+public class OciObjectStoragePluginIT extends OpenSearchRestTestCase {
+
+    private static final String TEST_REPOSITORY_NAME = "myTestRepository";
+
+    @Test
+    public void testItAll() throws IOException, NoSuchAlgorithmException, ExecutionException, InterruptedException {
+        final int testObjectStorageServerPort = 8081;
+
+        try (NonJerseyServer nonJerseyServer = new NonJerseyServer(testObjectStorageServerPort)) {
+            SocketAccess.doPrivilegedVoidIOException(nonJerseyServer::start);
+            try (final RestHighLevelClient restHighLevelClient = getRestHighLevelClient()) {
+                logger.info("1. Test cluster can load the plugin");
+                // 1. Test cluster can load the plugin
+                testExternalStatusShowsGreen(restHighLevelClient);
+
+                logger.info("2. Repository creation");
+                // 2. Repository creation
+                testCreateRepository(restHighLevelClient, nonJerseyServer.getUrl());
+
+                logger.info("3. Snapshot and restore testing");
+                // 3. Snapshot and restore testing
+                testSnapshotAndRestore(restHighLevelClient);
+
+                logger.info("4. Delete snapshot from repository");
+                // 4. Delete snapshot from repository
+                testDeleteSnapshotFromRepository(restHighLevelClient);
+
+                SocketAccess.doPrivilegedVoidIOException(nonJerseyServer::close);
+            }
+        }
+    }
+
+    private void testCreateRepository(RestHighLevelClient restHighLevelClient, String testObjectStorageUrl)
+            throws IOException, NoSuchAlgorithmException {
+        PutRepositoryRequest putRepositoryRequest = new PutRepositoryRequest();
+        putRepositoryRequest.masterNodeTimeout(TimeValue.timeValueSeconds(10));
+        putRepositoryRequest.settings(TestConstants.getRepositorySettings(testObjectStorageUrl));
+        putRepositoryRequest.type("oci");
+        putRepositoryRequest.name(TEST_REPOSITORY_NAME);
+        final AcknowledgedResponse acknowledgedResponse =
+                restHighLevelClient
+                        .snapshot()
+                        .createRepository(putRepositoryRequest, RequestOptions.DEFAULT);
+        logger.info("Create repository response {}", acknowledgedResponse);
+        final GetRepositoriesRequest getRepositoriesRequest = new GetRepositoriesRequest();
+        getRepositoriesRequest.masterNodeTimeout(TimeValue.timeValueSeconds(10));
+        final GetRepositoriesResponse getRepositoriesResponse =
+                restHighLevelClient
+                        .snapshot()
+                        .getRepository(getRepositoriesRequest, RequestOptions.DEFAULT);
+        Assertions.assertThat(getRepositoriesResponse.repositories().size()).isEqualTo(1);
+        Assertions.assertThat(getRepositoriesResponse.repositories().get(0).name())
+                .isEqualTo(TEST_REPOSITORY_NAME);
+    }
+
+    private void testExternalStatusShowsGreen(RestHighLevelClient restHighLevelClient)
+            throws IOException {
+        // 1. Test cluster can load the plugin
+        logger.info("testing rest request");
+        final ClusterHealthResponse clusterHealthResponse =
+                restHighLevelClient
+                        .cluster()
+                        .health(
+                                new ClusterHealthRequest().waitForGreenStatus(),
+                                RequestOptions.DEFAULT);
+        logger.info("rest response received {}", clusterHealthResponse);
+        Assertions.assertThat(clusterHealthResponse.getStatus())
+                .isEqualTo(ClusterHealthStatus.GREEN);
+    }
+
+    private void testSnapshotAndRestore(final RestHighLevelClient restClient)
+            throws IOException, ExecutionException, InterruptedException {
+        // Create 3 snapshots
+        createPopulatedTestIndex("my_test_index1", restClient);
+        testExternalStatusShowsGreen(restClient);
+        snapshotCluster(TEST_REPOSITORY_NAME, "my_snapshot1", restClient);
+        updateIndexWithNewDoc("my_test_index1", restClient, 1);
+        createPopulatedTestIndex("my_test_index2", restClient);
+        testExternalStatusShowsGreen(restClient);
+        snapshotCluster(TEST_REPOSITORY_NAME, "my_snapshot2", restClient);
+        updateIndexWithNewDoc("my_test_index1", restClient, 2);
+        createPopulatedTestIndex("my_test_index3", restClient);
+        testExternalStatusShowsGreen(restClient);
+        snapshotCluster(TEST_REPOSITORY_NAME, "my_snapshot3", restClient);
+
+        // Restore and test content of each snapshot
+        cleanupAllIndices(restClient);
+        restoreSnapshot(TEST_REPOSITORY_NAME, "my_snapshot1", restClient);
+        searchIndex(restClient, "restored_snapshot_my_snapshot1" + "my_test_index1", 1);
+
+        cleanupAllIndices(restClient);
+        restoreSnapshot(TEST_REPOSITORY_NAME, "my_snapshot2", restClient);
+        searchIndex(restClient, "restored_snapshot_my_snapshot2" + "my_test_index1", 2);
+        searchIndex(restClient, "restored_snapshot_my_snapshot2" + "my_test_index2", 1);
+
+        cleanupAllIndices(restClient);
+        restoreSnapshot(TEST_REPOSITORY_NAME, "my_snapshot3", restClient);
+        searchIndex(restClient, "restored_snapshot_my_snapshot3" + "my_test_index1", 3);
+        searchIndex(restClient, "restored_snapshot_my_snapshot3" + "my_test_index2", 1);
+        searchIndex(restClient, "restored_snapshot_my_snapshot3" + "my_test_index3", 1);
+    }
+
+    private void testDeleteSnapshotFromRepository(RestHighLevelClient restHighLevelClient) throws IOException {
+        snapshotCluster(TEST_REPOSITORY_NAME, "my_temp_test_snapshot1", restHighLevelClient);
+        final DeleteSnapshotRequest deleteSnapshotRequest = new DeleteSnapshotRequest();
+        deleteSnapshotRequest.repository(TEST_REPOSITORY_NAME)
+                .snapshots("my_temp_test_snapshot1");
+        restHighLevelClient.snapshot().delete(deleteSnapshotRequest, RequestOptions.DEFAULT);
+
+        final GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest();
+        getSnapshotsRequest.repository(TEST_REPOSITORY_NAME);
+
+        final GetSnapshotsResponse getSnapshotsResponse = restHighLevelClient.snapshot().get(getSnapshotsRequest, RequestOptions.DEFAULT);
+        logger.info("get snapshots response: {}", getSnapshotsResponse);
+        Assertions.assertThat(getSnapshotsResponse.getSnapshots().size()).isEqualTo(3);
+    }
+
+    private void snapshotCluster(
+            String repositoryName, String snapshotName, RestHighLevelClient restClient) throws IOException {
+        final CreateSnapshotRequest createSnapshotRequest = new CreateSnapshotRequest();
+        try {
+            createSnapshotRequest.snapshot(snapshotName);
+            createSnapshotRequest.repository(repositoryName);
+            createSnapshotRequest.indices(List.of(ALL_SNAPSHOTS));
+            createSnapshotRequest.includeGlobalState(false);
+            createSnapshotRequest.waitForCompletion(true);
+            final CreateSnapshotResponse createSnapshotResponse =
+                    restClient.snapshot().create(createSnapshotRequest, RequestOptions.DEFAULT);
+            logger.info(
+                    "Snapshot response for snapshot {}, response {}",
+                    snapshotName,
+                    createSnapshotResponse);
+            Assertions.assertThat(createSnapshotResponse.getSnapshotInfo().state().name())
+                    .isEqualTo("SUCCESS");
+        } catch (OpenSearchStatusException e) {
+            if (e.status().getStatus() == 404) {
+                logger.info(
+                        "Unable to snapshot repository {} since the repository cannot be found",
+                        repositoryName);
+            } else {
+                logger.error("Unable to snapshot repository {}", repositoryName);
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void restoreSnapshot(
+            String repositoryName,
+            String snapshotName,
+            RestHighLevelClient restClient)
+            throws IOException {
+        final RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest();
+        restoreSnapshotRequest.repository(repositoryName).snapshot(snapshotName)
+                .renamePattern("(.+)")
+                .renameReplacement("restored_snapshot_" + snapshotName + "$1");
+
+        RestoreSnapshotResponse restoreSnapshotResponse =
+                restClient.snapshot().restore(restoreSnapshotRequest, RequestOptions.DEFAULT);
+
+        logger.info("restore snapshot response: {}", restoreSnapshotResponse);
+        testExternalStatusShowsGreen(restClient);
+    }
+
+    private void cleanupAllIndices(RestHighLevelClient restClient)
+            throws IOException {
+        final DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest();
+        deleteIndexRequest.indices("*");
+        restClient.indices().delete(deleteIndexRequest, RequestOptions.DEFAULT);
+        testExternalStatusShowsGreen(restClient);
+    }
+
+    private SearchResponse searchIndex(
+            RestHighLevelClient restHighLevelClient, String indexName, int expectedResults)
+            throws IOException {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices(indexName);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+        searchSourceBuilder.size(10000);
+        searchRequest.source(searchSourceBuilder);
+        final SearchResponse searchResponse =
+                restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+
+        logger.info("got search index response to test metrics {}", searchResponse);
+        Assertions.assertThat(searchResponse.getHits().getTotalHits().value)
+                .isEqualTo(expectedResults);
+        return searchResponse;
+    }
+
+    private void createPopulatedTestIndex(String indexName, RestHighLevelClient restHighLevelClient)
+            throws IOException, ExecutionException, InterruptedException {
+        createTestIndex(indexName, restHighLevelClient);
+        updateIndexWithNewDoc(indexName, restHighLevelClient, 0);
+    }
+
+    private void createTestIndex(String indexName, RestHighLevelClient restHighLevelClient)
+            throws IOException {
+        logger.info("Creating sample test index {}", indexName);
+
+        final int indexReplicas = 0;
+        final CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
+        createIndexRequest.settings(
+                Settings.builder()
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", indexReplicas)
+                    .build());
+
+        restHighLevelClient.indices().create(createIndexRequest, RequestOptions.DEFAULT);
+    }
+
+    private void updateIndexWithNewDoc(String indexName, RestHighLevelClient restHighLevelClient, int docNum)
+            throws IOException {
+        final String fieldName = "test_field";
+        final String docId = "test_doc_id_" + docNum;
+        final String docContent = "{\"myField\": \"somet test information\"}";
+
+        final UpdateRequest updateRequest = new UpdateRequest(indexName, docId);
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject();
+            final InputStream stream =
+                    new ByteArrayInputStream(docContent.getBytes(StandardCharsets.UTF_8));
+            builder.rawField(fieldName, stream, XContentType.JSON);
+            builder.endObject();
+            updateRequest.doc(builder).upsert(builder);
+        } catch (IOException e) {
+            logger.error("Unable to create Manifest payload to ES", e);
+            throw e;
+        }
+
+        restHighLevelClient.update(updateRequest, RequestOptions.DEFAULT);
+        logger.info("Successfully persisted record with value: {}", docContent);
+    }
+
+    /**
+     * Get the high level rest client for elastic search support
+     *
+     * @return RestHighLevelClient
+     */
+    public RestHighLevelClient getRestHighLevelClient() {
+        RestClient restClient = client();
+        final Node[] nodes = new Node[restClient.getNodes().size()];
+        restClient.getNodes().toArray(nodes);
+        final RestClientBuilder restClientBuilder = RestClient.builder(nodes);
+        return new RestHighLevelClient(restClientBuilder);
+    }
+}

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
@@ -21,8 +21,6 @@ import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotReques
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
-import org.opensearch.action.admin.cluster.stats.ClusterStatsResponse;
-import org.opensearch.action.admin.indices.get.GetIndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateRequest;

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/TestConstants.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/TestConstants.java
@@ -21,14 +21,17 @@ import java.security.NoSuchAlgorithmException;
 import static org.opensearch.repositories.oci.OciObjectStorageClientSettings.DEV_REGION;
 
 public class TestConstants {
-
     public static Settings getRepositorySettings() throws NoSuchAlgorithmException, IOException {
+        return getRepositorySettings("http://localhost:8080");
+    }
+
+    public static Settings getRepositorySettings(String url) throws NoSuchAlgorithmException, IOException {
         final Path keyFile = CryptoUtils.generatePrivatePublicKeyPair();
 
         return Settings.builder()
                 .put(
                         OciObjectStorageClientSettings.ENDPOINT_SETTING.getKey(),
-                        "http://localhost:8080")
+                        url)
                 .put(OciObjectStorageClientSettings.REGION_SETTING.getKey(), DEV_REGION)
                 .put(OciObjectStorageClientSettings.CREDENTIALS_FILE_SETTING.getKey(), keyFile)
                 .put(OciObjectStorageClientSettings.INSTANCE_PRINCIPAL.getKey(), false)


### PR DESCRIPTION
### Description
This change fixes the issue of transient dependency resolution for the OCI obcjectstorage plugin plus some cleanups.
1. Fix dependency resolution for SDK dependencies.
2. Add restIntegTest
3. cleanup and allow `build` to pass

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [https://github.com/opensearch-project/opensearch-oci-object-storage/issues/35]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
