### PR TITLE
upgrade oci sdk and opensearch to 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build the plugin zip distribution file and running all the tests
 Install the plugin on your OpenSearch cluster
 ```bash
 OPENSEARCH_HOME=<YOUR OPENSEARCH INSTALLATION PATH HERE> # (e.g. /Users/saherman/opensearch)
-${OPENSEARCH_HOME}/bin/opensearch-plugin install file://oci-repository-plugin/build/distributions/repository-oci-2.5.0.zip
+${OPENSEARCH_HOME}/bin/opensearch-plugin install file://oci-repository-plugin/build/distributions/repository-oci-2.6.0.zip
 ```
 
 Start your cluster.

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 allprojects {
-    version = '2.5.0'
+    version = '2.6.0'
 }
 
 subprojects {
@@ -26,9 +26,9 @@ subprojects {
     apply plugin: 'jacoco'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.5.0")
-        sdk_version = "3.3.0"
-        jackson_version = "2.14.1"
+        opensearch_version = System.getProperty("opensearch.version", "2.6.0")
+        sdk_version = "3.7.0"
+        jackson_version = "2.14.2"
     }
 
     repositories {
@@ -36,10 +36,6 @@ subprojects {
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-    }
-
-    configurations.runtimeClasspath {
-        exclude group: 'javax.annotation', module: 'javax.annotation-api'
     }
 
     // Fix dependency collision with opensearch
@@ -53,6 +49,7 @@ subprojects {
             force "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jackson_version}"
             force "commons-codec:commons-codec:1.15"
             force "org.apache.httpcomponents:httpcore:4.4.15"
+            force "jakarta.annotation:jakarta.annotation-api:2.1.1"
         }
     }
 

--- a/oci-repository-plugin/build.gradle
+++ b/oci-repository-plugin/build.gradle
@@ -78,9 +78,6 @@ buildscript {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
     }
 }
-configurations.testImplementation {
-    exclude group: 'javax.annotation', module: 'javax.annotation-api'
-}
 
 dependencies {
     testImplementation(project(":oci-objectstorage-fixture")) {


### PR DESCRIPTION
### Description
Upgrade OCI SDK to 3.7.0 and open search to 2.6.0

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-oci-object-storage/issues/34.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
