### PR TITLE
fix path bugs, fix fixture issue with head request for empty objects

### DIFF
--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobContainer.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobContainer.java
@@ -26,17 +26,15 @@ import java.util.stream.Collectors;
 class OciObjectStorageBlobContainer extends AbstractBlobContainer {
 
     private final OciObjectStorageBlobStore blobStore;
-    private final String path;
 
     OciObjectStorageBlobContainer(BlobPath path, OciObjectStorageBlobStore blobStore) {
         super(path);
         this.blobStore = blobStore;
-        this.path = path.buildAsString();
     }
 
     @Override
     public Map<String, BlobMetadata> listBlobs() throws IOException {
-        return blobStore.listBlobs(path);
+        return blobStore.listBlobs(path().buildAsString());
     }
 
     @Override
@@ -46,7 +44,7 @@ class OciObjectStorageBlobContainer extends AbstractBlobContainer {
 
     @Override
     public Map<String, BlobMetadata> listBlobsByPrefix(String prefix) throws IOException {
-        return blobStore.listBlobsByPrefix(path, prefix);
+        return blobStore.listBlobsByPrefix(path().buildAsString(), prefix);
     }
 
     @Override
@@ -61,7 +59,7 @@ class OciObjectStorageBlobContainer extends AbstractBlobContainer {
 
     @Override
     public InputStream readBlob(String blobName, long position, long length) throws IOException {
-        return blobStore.readBlob(blobName, position, length);
+        return blobStore.readBlob(buildKey(blobName), position, length);
     }
 
     @Override
@@ -91,6 +89,6 @@ class OciObjectStorageBlobContainer extends AbstractBlobContainer {
 
     private String buildKey(String blobName) {
         assert blobName != null;
-        return path + blobName;
+        return path().add(blobName).buildAsString();
     }
 }

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStorageBlobStoreTests.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStorageBlobStoreTests.java
@@ -30,12 +30,6 @@ import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
-import org.opensearch.common.blobstore.BlobStoreException;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
-import org.opensearch.common.blobstore.DeleteResult;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.fixtures.oci.NonJerseyServer;
 
 import java.io.ByteArrayInputStream;
@@ -43,10 +37,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class OciObjectStorageBlobStoreTests {
 
@@ -72,7 +62,8 @@ public class OciObjectStorageBlobStoreTests {
         final OciObjectStorageBlobStore blobStore =
                 new OciObjectStorageBlobStore(new OciObjectStorageService(), repositoryMetadata);
 
-        final BlobContainer rootBlobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        final BlobPath basePath = BlobPath.cleanPath().add(OciObjectStorageRepository.BASE_PATH_SETTING.get(repositoryMetadata.settings()));
+        final BlobContainer rootBlobContainer = blobStore.blobContainer(basePath);
 
         final String blobData1 = "myBlobData1";
         final String blobData2 = "myBlobData1";
@@ -143,7 +134,8 @@ public class OciObjectStorageBlobStoreTests {
         final OciObjectStorageBlobStore blobStore =
                 new OciObjectStorageBlobStore(new OciObjectStorageService(), repositoryMetadata);
 
-        final BlobContainer rootBlobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        final BlobPath basePath = BlobPath.cleanPath().add(OciObjectStorageRepository.BASE_PATH_SETTING.get(repositoryMetadata.settings()));
+        final BlobContainer rootBlobContainer = blobStore.blobContainer(basePath);
 
         final String blobData = "myBlobData";
         final byte[] blobBytes = blobData.getBytes(StandardCharsets.UTF_8);
@@ -166,7 +158,8 @@ public class OciObjectStorageBlobStoreTests {
         final OciObjectStorageBlobStore blobStore =
                 new OciObjectStorageBlobStore(new OciObjectStorageService(), repositoryMetadata);
 
-        final BlobContainer rootBlobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        final BlobPath basePath = BlobPath.cleanPath().add(OciObjectStorageRepository.BASE_PATH_SETTING.get(repositoryMetadata.settings()));
+        final BlobContainer rootBlobContainer = blobStore.blobContainer(basePath);
 
         final String blobData1 = "myBlobData1";
         final String blobData2 = "myBlobData1";
@@ -201,7 +194,8 @@ public class OciObjectStorageBlobStoreTests {
         final OciObjectStorageBlobStore blobStore =
                 new OciObjectStorageBlobStore(new OciObjectStorageService(), repositoryMetadata);
 
-        final BlobContainer rootBlobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        final BlobPath basePath = BlobPath.cleanPath().add(OciObjectStorageRepository.BASE_PATH_SETTING.get(repositoryMetadata.settings()));
+        final BlobContainer rootBlobContainer = blobStore.blobContainer(basePath);
 
         final String blobData = "myBlobData";
         final byte[] blobBytes = blobData.getBytes(StandardCharsets.UTF_8);
@@ -223,7 +217,8 @@ public class OciObjectStorageBlobStoreTests {
         final OciObjectStorageBlobStore blobStore =
                 new OciObjectStorageBlobStore(new OciObjectStorageService(), repositoryMetadata);
 
-        final BlobContainer rootBlobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        final BlobPath basePath = BlobPath.cleanPath().add(OciObjectStorageRepository.BASE_PATH_SETTING.get(repositoryMetadata.settings()));
+        final BlobContainer rootBlobContainer = blobStore.blobContainer(basePath);
 
         final String blobData = "myBlobData";
         final byte[] blobBytes = blobData.getBytes(StandardCharsets.UTF_8);
@@ -246,7 +241,8 @@ public class OciObjectStorageBlobStoreTests {
         final OciObjectStorageBlobStore blobStore =
                 new OciObjectStorageBlobStore(new OciObjectStorageService(), repositoryMetadata);
 
-        final BlobContainer rootBlobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        final BlobPath basePath = BlobPath.cleanPath().add(OciObjectStorageRepository.BASE_PATH_SETTING.get(repositoryMetadata.settings()));
+        final BlobContainer rootBlobContainer = blobStore.blobContainer(basePath);
 
         Map<String, BlobContainer> results = rootBlobContainer.children();
         Assertions.assertThat(results.values().size()).isEqualTo(0);


### PR DESCRIPTION
### Description
1. Fixing path bugs related to build key when blob name is used.
2. Fix fixture issue for head request when object is empty.

### Issues Resolved
Previously when blobStoreContainer would call `public InputStream readBlob(String blobName, long position, long length)`
with a base path set, we would get a `404 object not found`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
