### PR TITLE
Bump OpenSearch version to 2.7.0, SDK version to 3.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 allprojects {
-    version = '2.6.0'
+    version = '2.7.0'
 }
 
 subprojects {
@@ -28,8 +28,8 @@ subprojects {
     apply plugin: 'com.diffplug.spotless'
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.6.0")
-        sdk_version = "3.7.0"
+        opensearch_version = System.getProperty("opensearch.version", "2.7.0-SNAPSHOT")
+        sdk_version = "3.10.0"
         jackson_version = "2.14.2"
     }
 

--- a/oci-objectstorage-fixture/build.gradle
+++ b/oci-objectstorage-fixture/build.gradle
@@ -22,7 +22,7 @@ version = '1.0'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(15)
+        languageVersion = JavaLanguageVersion.of(19)
     }
 }
 

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStoragePlugin.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStoragePlugin.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.plugins.Plugin;

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageRepository.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageRepository.java
@@ -25,7 +25,7 @@ import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
-import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.repositories.RepositoryException;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginIT.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginIT.java
@@ -40,7 +40,7 @@ import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.fixtures.oci.NonJerseyServer;

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
@@ -26,7 +26,7 @@ import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.*;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.fixtures.oci.NonJerseyServer;


### PR DESCRIPTION
### Description
- Bump OpenSearch version to 2.7.0
- Bump SDK version to 3.10.0
- Bump Java version for `oci-objectstorage-fixture` to Java 19
- Refactor `import org.opensearch.common.xcontent.*` to `import org.opensearch.core.xcontent.*`

*Sidenote*: I tested this locally by performing a `./gradlew publishToMavenLocal` on a local `2.x` branch for OpenSearch and tested the changes using the version `opensearch_version = System.getProperty("opensearch.version", "2.7.0-SNAPSHOT")`
We might need to cut a `2.7.0` tag for OpenSearch before merging this in.

### Issues Resolved
- Resolves #44 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
