### PR TITLE
Increase the timeout for putRequest to 60s from the current 5 seconds.

### DIFF
--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
@@ -705,7 +705,7 @@ class OciObjectStorageBlobStore implements BlobStore {
                                     public void onError(PutObjectRequest putObjectRequest, Throwable error) {
                                         log.error("error put object: {}, bucket: {}, namespace: {}", objectName, bucketName, namespace, error);
                                     }
-                                }).get(5, TimeUnit.SECONDS);
+                                }).get(60, TimeUnit.SECONDS);
                                 final Instant end = Instant.now();
                                 log.info(
                                         "Finished pushing object '/n/{}/b/{}/o/{}' in {} millis",


### PR DESCRIPTION
Increasing the timeout for putRequest to 60s from the current 5 seconds. Snapshot requests are failing in the OIC Dev environment due to the short timeout period for put requests.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
