### PR TITLE
Upgrade dependencies - guava 32.1.2-jre, spotless 6.21.0 and oci-java-sdk 3.24.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ repositories {
 
 allprojects {
     version = '2.7.0'
+
+    // Force using a newer version, due to guava vulnerability CVE-2023-2976. Remove after Gradle upgrades its default version.
+    checkstyle {
+        toolVersion = "10.12.3"
+    }
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'jacoco'
     id 'java'
     id 'java-library'
-    id "com.diffplug.spotless" version "6.17.0"
+    id "com.diffplug.spotless" version "6.21.0"
 }
 
 repositories {
@@ -52,12 +52,14 @@ subprojects {
             force "commons-codec:commons-codec:1.15"
             force "org.apache.httpcomponents:httpcore:4.4.15"
             force "jakarta.annotation:jakarta.annotation-api:2.1.1"
+            // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
+            force "com.google.guava:guava:32.1.2-jre"
         }
     }
 
     dependencies {
         implementation "net.jodah:failsafe:2.4.0"
-        implementation "com.google.guava:guava:31.1-jre"
+        implementation "com.google.guava:guava:32.1.2-jre"
         implementation "org.apache.commons:commons-lang3:3.9"
         implementation "commons-io:commons-io:2.7"
         /******************** Hacking transient dependencies for OCI SDK ********************/
@@ -130,7 +132,7 @@ subprojects {
             removeUnusedImports()
 
             // apply a specific flavor of google-java-format
-            googleJavaFormat('1.16.0').aosp().reflowLongStrings()
+            googleJavaFormat().aosp().reflowLongStrings()
             // fix formatting of type annotations
             formatAnnotations()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,6 @@ repositories {
 
 allprojects {
     version = '2.7.0'
-
-    // Force using a newer version, due to guava vulnerability CVE-2023-2976. Remove after Gradle upgrades its default version.
-    checkstyle {
-        toolVersion = "10.12.3"
-    }
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
 
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.7.0-SNAPSHOT")
-        sdk_version = "3.10.0"
+        sdk_version = "3.24.0"
         jackson_version = "2.14.2"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,9 @@ repositories {
 allprojects {
     version = '2.7.0'
 
-    // Force spotless and checkstyle depending on newer version of guava due to CVE-2023-2976. Remove after they both upgrades.
-    configurations.all {
-        resolutionStrategy {
-            force "com.google.guava:guava:32.1.2-jre"
-        }
+    // Force using a newer version, due to guava vulnerability CVE-2023-2976. Remove after Gradle upgrades its default version.
+    checkstyle {
+        toolVersion = "10.12.3"
     }
 }
 
@@ -59,6 +57,8 @@ subprojects {
             force "commons-codec:commons-codec:1.15"
             force "org.apache.httpcomponents:httpcore:4.4.15"
             force "jakarta.annotation:jakarta.annotation-api:2.1.1"
+            // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
+            force "com.google.guava:guava:32.1.2-jre"
             // Force opensearch transport-netty4-client depending on newer version of netty-handler due to CVE-2023-34462.
             // Remove after upgrading the compiled opensearch version.
             force "io.netty:netty-handler:4.1.94.Final"

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ subprojects {
             force "commons-codec:commons-codec:1.15"
             force "org.apache.httpcomponents:httpcore:4.4.15"
             force "jakarta.annotation:jakarta.annotation-api:2.1.1"
+            // Force opensearch transport-netty4-client depending on newer version of netty-handler due to CVE-2023-34462.
+            // Remove after upgrading the compiled opensearch version.
+            force "io.netty:netty-handler:4.1.94.Final"
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,13 @@ repositories {
 
 allprojects {
     version = '2.7.0'
+
+    // Force spotless and checkstyle depending on newer version of guava due to CVE-2023-2976. Remove after they both upgrades.
+    configurations.all {
+        resolutionStrategy {
+            force "com.google.guava:guava:32.1.2-jre"
+        }
+    }
 }
 
 subprojects {
@@ -52,8 +59,6 @@ subprojects {
             force "commons-codec:commons-codec:1.15"
             force "org.apache.httpcomponents:httpcore:4.4.15"
             force "jakarta.annotation:jakarta.annotation-api:2.1.1"
-            // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
-            force "com.google.guava:guava:32.1.2-jre"
         }
     }
 


### PR DESCRIPTION
### Description

- Bump `com.google.guava:guava` version from `31.1-jre` to `32.1.2-jre`
- Bump `com.diffplug.spotless` version from `6.17.0` to `6.21.0`
- Bump `oci-java-sdk` version from `3.10.0` to `3.24.0`
- Set dependency resolution strategy to use `guava` version `32.1.2-jre` for all Gradle projects.
Reference: https://github.com/opensearch-project/OpenSearch/commit/134257816acfa69db9b1a969e1854f4ece5a6e55
- Set dependency resolution strategy to use `netty-handler` version `4.1.94-Final` for sub-project `oci-repository-plugin`.

Reason:
There is a guava vulnerability CVE-2023-2976 (GHSA-7g45-4rm6-3mm3).
There are 3 use cases in the code base that use older version of guava:
1. A dependency of OCI Repository plugin to compile source code.
2. A dependency of Gradle plugin. `spotless`.
3. A dependency of Gradle core plugin `checksytle`.

There are also 2 medium level vulnerabilities that resolved in the PR.
1. One is resolved by upgrading `oci-java-sdk`
2. The other one needs to upgrade the compiled OpenSearch version of OCI Repository plugin.
Currently the plugin is compiled with OpenSearch 2.7.0, it needs a separate PR to make it compatible with newer OpenSearch version. As a workaround, I applied another resolution strategy of dependency version to `netty-handler` to resolve the vulnerability alert.

After the code change, it can be seen that only the newer version of `guava` is being used:
./gradlew dependencies
```
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:8.45.1
     +--- info.picocli:picocli:4.6.1
     +--- antlr:antlr:2.7.7
     +--- org.antlr:antlr4-runtime:4.9.2
     +--- commons-beanutils:commons-beanutils:1.9.4
     |    \--- commons-collections:commons-collections:3.2.2
     +--- com.google.guava:guava:30.1.1-jre -> 32.1.2-jre
     |    +--- com.google.guava:guava-parent:32.1.2-jre
     |    |    +--- com.google.code.findbugs:jsr305:3.0.2 (c)
     |    |    +--- org.checkerframework:checker-qual:3.33.0 (c)
     |    |    \--- com.google.errorprone:error_prone_annotations:2.18.0 (c)
     |    +--- com.google.guava:failureaccess:1.0.1
     |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     |    +--- com.google.code.findbugs:jsr305 -> 3.0.2
     |    +--- org.checkerframework:checker-qual -> 3.33.0
     |    \--- com.google.errorprone:error_prone_annotations -> 2.18.0
     +--- org.reflections:reflections:0.9.12
     |    \--- org.javassist:javassist:3.26.0-GA
     \--- net.sf.saxon:Saxon-HE:10.5

```

./gradlew oci-repository-plugin:dependencies
```
spotless865457264 - [com.google.googlejavaformat:google-java-format:1.17.0]
\--- com.google.googlejavaformat:google-java-format:1.17.0
     \--- com.google.guava:guava:31.1-jre -> 32.1.2-jre
          +--- com.google.guava:guava-parent:32.1.2-jre
          |    +--- com.google.code.findbugs:jsr305:3.0.2 (c)
          |    +--- org.checkerframework:checker-qual:3.33.0 (c)
          |    \--- com.google.errorprone:error_prone_annotations:2.18.0 (c)
          +--- com.google.guava:failureaccess:1.0.1
          +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
          +--- com.google.code.findbugs:jsr305 -> 3.0.2
          +--- org.checkerframework:checker-qual -> 3.33.0
          \--- com.google.errorprone:error_prone_annotations -> 2.18.0
...
\--- org.opensearch.plugin:transport-netty4-client:2.7.0-SNAPSHOT
     +--- io.netty:netty-buffer:4.1.91.Final
     +--- io.netty:netty-codec:4.1.91.Final
     +--- io.netty:netty-codec-http:4.1.91.Final
     +--- io.netty:netty-common:4.1.91.Final
     +--- io.netty:netty-handler:4.1.91.Final -> 4.1.94.Final
     +--- io.netty:netty-resolver:4.1.91.Final
     +--- io.netty:netty-transport:4.1.91.Final
     \--- io.netty:netty-transport-native-unix-common:4.1.91.Final

```

### Issues Resolved
Resolve security vulnerability scanners complain about guava vulnerability CVE-2023-2976(GHSA-7g45-4rm6-3mm3).
For example, in the PR check https://github.com/opensearch-project/opensearch-oci-object-storage/pull/56/checks?check_run_id=16429779859, there are 3 vulnerabilities.
```
[CVE-2023-2976](https://www.mend.io/vulnerability-database/CVE-2023-2976)

Path to dependency file: /build.gradle

Path to vulnerable library: /home/wss-scanner/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/30.1.1-jre/87e0fd1df874ea3cbe577702fe6f17068b790fd8/guava-30.1.1-jre.jar

Dependency Hierarchy:

-> checkstyle-8.45.1.jar (Root Library)

   -> ❌ guava-30.1.1-jre.jar (Vulnerable Library)
```
```
[CVE-2023-33201](https://www.mend.io/vulnerability-database/CVE-2023-33201)

Path to dependency file: /oci-repository-plugin/build.gradle

Path to vulnerable library: /home/wss-scanner/.gradle/caches/modules-2/files-2.1/org.bouncycastle/bcprov-jdk15on/1.70/4636a0d01f74acaf28082fb62b317f1080118371/bcprov-jdk15on-1.70.jar,/home/wss-scanner/.gradle/caches/modules-2/files-2.1/org.bouncycastle/bcprov-jdk15on/1.70/4636a0d01f74acaf28082fb62b317f1080118371/bcprov-jdk15on-1.70.jar

Dependency Hierarchy:

-> oci-java-sdk-objectstorage-3.10.0.jar (Root Library)

   -> oci-java-sdk-objectstorage-generated-3.10.0.jar

     -> oci-java-sdk-common-3.10.0.jar

       -> ❌ bcprov-jdk15on-1.70.jar (Vulnerable Library)
```
```
[CVE-2023-34462](https://www.mend.io/vulnerability-database/CVE-2023-34462)

Path to dependency file: /oci-repository-plugin/build.gradle

Path to vulnerable library: /home/wss-scanner/.gradle/caches/modules-2/files-2.1/io.netty/netty-handler/4.1.91.Final/444cf41e4fe28c47ffebba5e77b9458a12f938a1/netty-handler-4.1.91.Final.jar

Dependency Hierarchy:

-> transport-netty4-client-2.7.0-SNAPSHOT.jar (Root Library)

   -> ❌ netty-handler-4.1.91.Final.jar (Vulnerable Library)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
