### PR TITLE
Move andrross to emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,5 +10,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
 | Vacha Shah        | [VachaShah](https://github.com/VachaShah)               | Amazon      |
 | Kunal Kotwani     | [kotwanikunal](https://github.com/kotwanikunal)         | Amazon      |
-| Andrew Ross       | [andrross](https://github.com/andrross)                 | Amazon      |
 | Anas Alkouz       | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
+
+## Emeritus
+
+| Maintainer        | GitHub ID                                               | Affiliation |
+| Andrew Ross       | [andrross](https://github.com/andrross)                 | Amazon      |


### PR DESCRIPTION
This commit moves me to emeritus as I don't expect to be actively involved in this repository in the foreseeable future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
