### PR TITLE
Moving saratvemulapalli to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @samuel-oci @saratvemulapalli @VachaShah @anasalkouz
+*   @samuel-oci @VachaShah @anasalkouz

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer        | GitHub ID                                               | Affiliation |
 |-------------------|---------------------------------------------------------| ----------- |
 | Samuel            | [samuel-oci](https://github.com/samuel-oci)             | Oracle      |
-| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
 | Vacha Shah        | [VachaShah](https://github.com/VachaShah)               | Amazon      |
 | Anas Alkouz       | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
 
@@ -17,3 +16,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 |-------------------|---------------------------------------------------------| ----------- |
 | Andrew Ross       | [andrross](https://github.com/andrross)                 | Amazon      |
 | Kunal Kotwani     | [kotwanikunal](https://github.com/kotwanikunal)         | Amazon      |
+| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |


### PR DESCRIPTION
### Description
Moving to Emeritus as I no longer intend to be an active maintainer of this repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
