### PR TITLE
Fix: ObjectStore client connections leaking during UTs

### DIFF
--- a/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/OciHttpHandler.java
+++ b/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/OciHttpHandler.java
@@ -238,7 +238,7 @@ public class OciHttpHandler implements HttpHandler {
                 bucketName,
                 objectName);
         exchange.getResponseHeaders().add("Content-Type", "application/json");
-        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), 0);
+        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
         exchange.close();
     }
 
@@ -289,8 +289,6 @@ public class OciHttpHandler implements HttpHandler {
         final LocalBucket bucket = buckets.get(bucketName);
         final OSObject object = bucket.getObject(objectName);
         if (object != null) {
-            exchange.getResponseHeaders().add("Content-Type", "application/json");
-            exchange.sendResponseHeaders(RestStatus.OK.getStatus(), 0);
             final HeadObjectResponse headObjectResponse =
                     HeadObjectResponse.builder()
                             .contentLength((long) object.getBytes().length)
@@ -299,7 +297,7 @@ public class OciHttpHandler implements HttpHandler {
             final byte[] response = str.getBytes(StandardCharsets.UTF_8);
 
             exchange.getResponseHeaders().add("Content-Type", "application/json");
-            exchange.sendResponseHeaders(RestStatus.OK.getStatus(), 0);
+            exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
             exchange.getResponseBody().write(response);
             exchange.close();
         } else {
@@ -334,7 +332,7 @@ public class OciHttpHandler implements HttpHandler {
         final byte[] response = str.getBytes(StandardCharsets.UTF_8);
 
         exchange.getResponseHeaders().add("Content-Type", "application/json");
-        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), 0);
+        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
         exchange.getResponseBody().write(response);
         exchange.close();
     }
@@ -354,7 +352,7 @@ public class OciHttpHandler implements HttpHandler {
 
         bucket.deleteObject(objectName);
         exchange.getResponseHeaders().add("Content-Type", "application/json");
-        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), 0);
+        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
         exchange.close();
     }
 

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
@@ -12,7 +12,6 @@
 package org.opensearch.repositories.oci;
 
 import com.oracle.bmc.ClientConfiguration;
-import com.oracle.bmc.http.client.jersey.ApacheClientProperties;
 import com.oracle.bmc.objectstorage.ObjectStorageAsync;
 import com.oracle.bmc.objectstorage.ObjectStorageAsyncClient;
 import java.io.Closeable;
@@ -20,7 +19,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.log4j.Log4j2;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 
 /** Service class to hold client instances */
@@ -74,33 +72,6 @@ public class OciObjectStorageService implements Closeable {
                 SocketAccess.doPrivilegedIOException(
                         () ->
                                 ObjectStorageAsyncClient.builder()
-                                        // This will run after, and in addition to, the default
-                                        // client configurator;
-                                        // this allows you to get the default behavior from the
-                                        // default client
-                                        // configurator
-                                        // (in the case of the ObjectStorageClient, the
-                                        // non-buffering behavior), but
-                                        // you
-                                        // can also add other things on top of it, like adding new
-                                        // headers
-
-                                        .additionalClientConfigurator(
-                                                builder -> {
-                                                    // Define a connection manager and its
-                                                    // properties
-                                                    final PoolingHttpClientConnectionManager
-                                                            poolConnectionManager =
-                                                                    new PoolingHttpClientConnectionManager();
-                                                    poolConnectionManager.setMaxTotal(100);
-                                                    poolConnectionManager.setDefaultMaxPerRoute(
-                                                            100);
-
-                                                    builder.property(
-                                                            ApacheClientProperties
-                                                                    .CONNECTION_MANAGER,
-                                                            poolConnectionManager);
-                                                })
                                         .configuration(ClientConfiguration.builder().build())
                                         .build(clientSettings.getAuthenticationDetailsProvider()));
 


### PR DESCRIPTION
### Description
OCI Object Store mocking service was improperly replying and leading to connection leak on client side.
Fixed by supplying content length = -1 - means not response body and connection can be reused or closed.
Added UT to spot similar issue in future.

### Check List
- [NA] New functionality includes testing.
- [NA] New functionality has been documented.
- [NA ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-oci-object-storage/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
