### PR TITLE
Simplifying dependency tree for oci-objectstorage-fixture

### DIFF
--- a/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/LocalBucket.java
+++ b/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/LocalBucket.java
@@ -1,6 +1,5 @@
 package org.opensearch.fixtures.oci;
 
-import com.google.common.base.Preconditions;
 import com.oracle.bmc.model.BmcException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,12 +17,8 @@ public class LocalBucket {
     Map<String, OSObject> prefixToObjectMap = new ConcurrentHashMap<>();
     String name;
 
-    public void putObject(String objectName, InputStream inputStream, int contentLength)
-            throws IOException {
-        Preconditions.checkArgument(
-                contentLength < Integer.MAX_VALUE,
-                "Local object storage is currently not designed to handle very large objects");
-        final byte[] objectData = IOUtils.readFully(inputStream, contentLength);
+    public void putObject(String objectName, InputStream inputStream) throws IOException {
+        final byte[] objectData = IOUtils.toByteArray(inputStream);
         final OSObject osObject = new OSObject(objectName, objectData);
         prefixToObjectMap.put(objectName, osObject);
     }


### PR DESCRIPTION
### Description
oci-objectstorage-fixture does not need to depend on OpenSearch common or core libs for simple Http operations.
UTs can use simple Java Http client.

### Check List
- [NA] New functionality includes testing.
- [NA] New functionality has been documented.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-oci-object-storage/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
