### PR TITLE
Relocating and shading OCI SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,67 +78,6 @@ subprojects {
     }
     
     dependencies {
-        implementation "net.jodah:failsafe:2.4.0"
-        implementation "com.google.guava:guava:32.1.2-jre"
-        implementation "org.apache.commons:commons-lang3:3.9"
-        implementation "commons-io:commons-io:2.14.0"
-        implementation "commons-logging:commons-logging:1.2"
-        implementation "commons-codec:commons-codec:1.15"
-        
-        /******************** Hacking transient dependencies for OCI SDK ********************/
-        // TODO: For some odd reason it seems that the OpenSearch gradle plugin overrides resolution of implementation
-        // configuration which is why this hack is needed so we can get the transient dependencies packaged properly
-
-
-        implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-common:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage-generated:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage-extensions:${sdk_version}")
-        implementation("com.oracle.oci.sdk:oci-java-sdk-circuitbreaker:${sdk_version}")
-
-        implementation("io.github.resilience4j:resilience4j-circuitbreaker:1.7.1")
-        implementation("io.github.resilience4j:resilience4j-core:1.7.1")
-        implementation("jakarta.ws.rs:jakarta.ws.rs-api:2.1.6")
-        implementation("org.glassfish.jersey.media:jersey-media-json-jackson:2.35")
-        implementation("org.glassfish.jersey.ext:jersey-entity-filtering:2.35")
-        implementation("org.glassfish.jersey.core:jersey-client:2.35")
-        implementation("org.glassfish.jersey.core:jersey-common:2.35")
-        implementation("org.glassfish.jersey.inject:jersey-hk2:2.35")
-        implementation("org.glassfish.jersey.connectors:jersey-apache-connector:2.35")
-        implementation("jakarta.annotation:jakarta.annotation-api:2.1.1")
-        implementation("org.glassfish.hk2.external:jakarta.inject:2.6.1")
-        implementation("org.glassfish.hk2.external:aopalliance-repackaged:2.6.1")
-        implementation("org.glassfish.hk2:hk2-locator:2.6.1")
-        implementation("org.glassfish.hk2:hk2-utils:2.6.1")
-        implementation("org.glassfish.hk2:osgi-resource-locator:1.0.3")
-        implementation("org.glassfish.hk2:hk2-api:2.6.1")
-        implementation("org.apache.httpcomponents:httpclient:4.5.14")
-        implementation("org.apache.httpcomponents:httpcore:4.4.15")
-        implementation("org.bouncycastle:bcpkix-jdk15to18:1.78.1")
-        implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
-        implementation("org.bouncycastle:bcutil-jdk15to18:1.78.1")
-        implementation("org.javassist:javassist:3.25.0-GA")
-        implementation("io.vavr:vavr:0.10.2")
-        implementation("io.vavr:vavr-match:0.10.2")
-
-        implementation("org.slf4j:slf4j-api") {
-            version {
-                strictly "1.7.33"
-            }
-        }
-        /******************************* End of transient dependency hack for OCI SDK*****************************************/
-
-        implementation("com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${jackson_version}")
-        implementation("com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:${jackson_version}")
-        implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jackson_version}")
-        implementation("com.fasterxml.jackson.core:jackson-annotations:${jackson_version}")
-        implementation("com.fasterxml.jackson.core:jackson-databind:${jackson_version}")
-        implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:${jackson_version}")
-
-        compileOnly "org.opensearch:opensearch:${opensearch_version}"
-
         // Test dependencies
         testImplementation 'org.assertj:assertj-core:3.18.1'
 

--- a/oci-objectstorage-client-shaded/build.gradle
+++ b/oci-objectstorage-client-shaded/build.gradle
@@ -1,0 +1,55 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+// Project to relocate and shade OCI SDK and its dependencies to escape conflicts with OpenSearch and
+// potentially other plugins that could be using OCI SDK
+
+buildscript {
+    repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+}
+
+plugins {
+    id 'com.gradleup.shadow' version '8.3.5'
+}
+
+apply plugin: 'com.gradleup.shadow'
+
+version = '1.0'
+
+jar {
+    enabled = false
+}
+
+dependencies {
+    // Please use compile only to prevent leaking original namespace to dependant projects.
+    // Works together with ShadowJar`s configurations = [project.configurations.compileClasspath]
+    compileOnly("com.oracle.oci.sdk:oci-java-sdk-common-httpclient:${sdk_version}")
+    compileOnly("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:${sdk_version}")
+    compileOnly("com.oracle.oci.sdk:oci-java-sdk-objectstorage:${sdk_version}")
+    compileOnly("com.oracle.oci.sdk:oci-java-sdk-common:${sdk_version}")
+    compileOnly("com.oracle.oci.sdk:oci-java-sdk-objectstorage-generated:${sdk_version}")
+    compileOnly("com.oracle.oci.sdk:oci-java-sdk-objectstorage-extensions:${sdk_version}")
+    compileOnly("com.oracle.oci.sdk:oci-java-sdk-circuitbreaker:${sdk_version}")
+}
+
+tasks.named('shadowJar', ShadowJar) {
+    configurations = [project.configurations.compileClasspath]
+    // Relocating dependencies with its transitive dependencies.
+    enableRelocation = true
+    relocationPrefix = "org.opensearch.repositories.oci.sdk"
+    archiveClassifier = ""
+    // Relocating META-INF/services
+    mergeServiceFiles()
+    // https://gradleup.com/shadow/getting-started/#default-java-groovy-tasks
+    // Default configuration excludes any JAR index or cryptographic signature files matching the following patterns:
+    //
+    //    META-INF/INDEX.LIST
+    //    META-INF/*.SF
+    //    META-INF/*.DSA
+    //    META-INF/*.RSA
+}
+
+tasks.build.dependsOn tasks.shadowJar

--- a/oci-objectstorage-fixture/build.gradle
+++ b/oci-objectstorage-fixture/build.gradle
@@ -24,8 +24,15 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 
 dependencies {
+    implementation(project(path: ':oci-objectstorage-client-shaded', configuration: 'shadow'))
+
+    implementation "commons-io:commons-io:2.14.0"
+    implementation "com.google.guava:guava:32.1.2-jre"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    implementation "org.apache.logging.log4j:log4j-api:2.21.0"
+    implementation "org.apache.logging.log4j:log4j-core:2.21.0"
+
     testImplementation 'junit:junit:4.13.2'
-    implementation("org.opensearch:opensearch:${opensearch_version}")
 }
 
 test {

--- a/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/LocalBucket.java
+++ b/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/LocalBucket.java
@@ -1,6 +1,5 @@
 package org.opensearch.fixtures.oci;
 
-import com.oracle.bmc.model.BmcException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -11,6 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.Value;
 import org.apache.commons.io.IOUtils;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.model.BmcException;
 
 @Value
 public class LocalBucket {

--- a/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/OciHttpHandler.java
+++ b/oci-objectstorage-fixture/src/main/java/org/opensearch/fixtures/oci/OciHttpHandler.java
@@ -7,13 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.oracle.bmc.model.Range;
-import com.oracle.bmc.objectstorage.model.Bucket;
-import com.oracle.bmc.objectstorage.model.CreateBucketDetails;
-import com.oracle.bmc.objectstorage.model.ListObjects;
-import com.oracle.bmc.objectstorage.model.ObjectSummary;
-import com.oracle.bmc.objectstorage.responses.HeadObjectResponse;
-import com.oracle.bmc.util.internal.StringUtils;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -24,6 +17,13 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.model.Range;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.Bucket;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.CreateBucketDetails;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.ListObjects;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.ObjectSummary;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.HeadObjectResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.util.internal.StringUtils;
 
 @Log4j2
 public class OciHttpHandler implements HttpHandler {
@@ -294,8 +294,8 @@ public class OciHttpHandler implements HttpHandler {
             final String str = MAPPER.writeValueAsString(headObjectResponse);
             final byte[] response = str.getBytes(StandardCharsets.UTF_8);
 
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, -1);
             exchange.getResponseHeaders().add("Content-Type", "application/json");
-            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
             exchange.getResponseBody().write(response);
             exchange.close();
         } else {

--- a/oci-objectstorage-fixture/src/test/java/org/opensearch/fixtures/oci/FixtureTests.java
+++ b/oci-objectstorage-fixture/src/test/java/org/opensearch/fixtures/oci/FixtureTests.java
@@ -1,26 +1,27 @@
 package org.opensearch.fixtures.oci;
 
-import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
-import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
-import com.oracle.bmc.http.client.jersey.ApacheClientProperties;
-import com.oracle.bmc.model.Range;
-import com.oracle.bmc.objectstorage.ObjectStorage;
-import com.oracle.bmc.objectstorage.ObjectStorageClient;
-import com.oracle.bmc.objectstorage.model.CreateBucketDetails;
-import com.oracle.bmc.objectstorage.requests.*;
-import com.oracle.bmc.objectstorage.responses.*;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.Region;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.http.client.jersey.ApacheClientProperties;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.model.Range;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorage;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageClient;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.CreateBucketDetails;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.requests.*;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.*;
 import lombok.extern.log4j.Log4j2;
 
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.commons.io.IOUtils;
+import org.opensearch.repositories.oci.sdk.org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.opensearch.common.io.Streams;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
@@ -203,7 +204,7 @@ public class FixtureTests {
                                 .build());
         log.info("getObjectResponse: {}", getObjectResponse);
         assertEquals(
-                "myContent", Streams.readFully(getObjectResponse.getInputStream()).utf8ToString());
+                "myContent", IOUtils.toString(getObjectResponse.getInputStream(),"UTF-8"));
 
         // 4.1
         final GetObjectResponse getObjectResponseWithRange =
@@ -216,7 +217,7 @@ public class FixtureTests {
                                 .build());
         log.info("getObjectResponse: {}", getObjectResponse);
         assertEquals(
-                "my", Streams.readFully(getObjectResponseWithRange.getInputStream()).utf8ToString());
+                "my", IOUtils.toString(getObjectResponseWithRange.getInputStream(),"UTF-8"));
 
         // 5. Delete object
         final DeleteObjectResponse deleteObjectResponse =

--- a/oci-repository-plugin/build.gradle
+++ b/oci-repository-plugin/build.gradle
@@ -47,6 +47,7 @@ publishing {
     }
 }
 
+
 opensearchplugin {
     name pluginName
     description pluginDescription
@@ -54,6 +55,7 @@ opensearchplugin {
     licenseFile rootProject.file('LICENSE.txt')
     noticeFile rootProject.file('NOTICE.txt')
 }
+
 
 // This requires an additional Jar not published as part of build-tools
 loggerUsageCheck.enabled = false
@@ -81,10 +83,17 @@ buildscript {
 }
 
 dependencies {
-    testImplementation(project(":oci-objectstorage-fixture")) {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-        exclude group: 'org.glassfish.hk2.external', module: 'jakarta.inject'
-    }
+    implementation(project(path: ':oci-objectstorage-client-shaded', configuration: 'shadow'))
+
+    compileOnly "org.opensearch:opensearch:${opensearch_version}"
+
+    implementation("org.apache.commons:commons-lang3:3.9")
+    implementation "commons-logging:commons-logging:1.2"
+    implementation ("net.jodah:failsafe:2.4.0")
+    implementation("jakarta.ws.rs:jakarta.ws.rs-api:2.1.6")
+
+    testImplementation(project(":oci-objectstorage-fixture"))
+
     testImplementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}")
     testImplementation("org.opensearch.test:framework:${opensearch_version}")
     testImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
@@ -14,20 +14,6 @@ package org.opensearch.repositories.oci;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 import static org.opensearch.repositories.oci.OciObjectStorageRepository.*;
 
-import com.oracle.bmc.model.BmcException;
-import com.oracle.bmc.model.Range;
-import com.oracle.bmc.objectstorage.ObjectStorageAsync;
-import com.oracle.bmc.objectstorage.model.CreateBucketDetails;
-import com.oracle.bmc.objectstorage.model.ObjectSummary;
-import com.oracle.bmc.objectstorage.requests.*;
-import com.oracle.bmc.objectstorage.responses.CreateBucketResponse;
-import com.oracle.bmc.objectstorage.responses.DeleteObjectResponse;
-import com.oracle.bmc.objectstorage.responses.GetBucketResponse;
-import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
-import com.oracle.bmc.objectstorage.responses.HeadObjectResponse;
-import com.oracle.bmc.objectstorage.responses.ListObjectsResponse;
-import com.oracle.bmc.objectstorage.responses.PutObjectResponse;
-import com.oracle.bmc.responses.AsyncHandler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -59,6 +45,20 @@ import org.opensearch.common.blobstore.support.PlainBlobMetadata;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.model.BmcException;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.model.Range;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageAsync;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.CreateBucketDetails;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.ObjectSummary;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.requests.*;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.CreateBucketResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.DeleteObjectResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.GetBucketResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.HeadObjectResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.ListObjectsResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.PutObjectResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.responses.AsyncHandler;
 
 // Lots of code duplication with OciObjectStorageBlobStore and OciObjectStorageBlobContainer
 // Re-using the code will require significant refactoring which is needed on both

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageClientSettings.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageClientSettings.java
@@ -14,10 +14,6 @@ package org.opensearch.repositories.oci;
 import static org.opensearch.common.settings.Setting.boolSetting;
 import static org.opensearch.common.settings.Setting.simpleString;
 
-import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
-import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider;
-import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.function.Supplier;
@@ -25,6 +21,10 @@ import lombok.extern.log4j.Log4j2;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.Region;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 
 /** Container for OCI object storage clients settings. */
 @Log4j2

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStoragePlugin.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStoragePlugin.java
@@ -11,7 +11,6 @@
 
 package org.opensearch.repositories.oci;
 
-import com.oracle.bmc.http.client.HttpProvider;
 import java.security.AccessController;
 import java.security.AllPermission;
 import java.security.Permission;
@@ -29,6 +28,7 @@ import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.RepositoryPlugin;
 import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.http.client.HttpProvider;
 
 /** The plugin class */
 public class OciObjectStoragePlugin extends Plugin implements RepositoryPlugin {

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
@@ -11,15 +11,15 @@
 
 package org.opensearch.repositories.oci;
 
-import com.oracle.bmc.ClientConfiguration;
-import com.oracle.bmc.objectstorage.ObjectStorageAsync;
-import com.oracle.bmc.objectstorage.ObjectStorageAsyncClient;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.ClientConfiguration;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageAsync;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageAsyncClient;
 
 /** Service class to hold client instances */
 @Log4j2

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStorageBlobStoreTests.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStorageBlobStoreTests.java
@@ -11,16 +11,16 @@
 
 package org.opensearch.repositories.oci;
 
-import com.oracle.bmc.objectstorage.ObjectStorage;
-import com.oracle.bmc.objectstorage.ObjectStorageAsync;
-import com.oracle.bmc.objectstorage.ObjectStorageAsyncClient;
-import com.oracle.bmc.objectstorage.ObjectStorageClient;
-import com.oracle.bmc.objectstorage.model.CreateBucketDetails;
-import com.oracle.bmc.objectstorage.requests.CreateBucketRequest;
-import com.oracle.bmc.objectstorage.requests.GetBucketRequest;
-import com.oracle.bmc.objectstorage.responses.CreateBucketResponse;
-import com.oracle.bmc.objectstorage.responses.GetBucketResponse;
-import com.oracle.bmc.responses.AsyncHandler;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorage;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageAsync;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageAsyncClient;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageClient;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.model.CreateBucketDetails;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.requests.CreateBucketRequest;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.requests.GetBucketRequest;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.CreateBucketResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.responses.GetBucketResponse;
+import org.opensearch.repositories.oci.sdk.com.oracle.bmc.responses.AsyncHandler;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.AfterClass;

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,5 +12,6 @@ plugins {
 }
 
 rootProject.name = 'oci-opensearch-repository'
+include('oci-objectstorage-client-shaded')
 include('oci-objectstorage-fixture')
 include('oci-repository-plugin')


### PR DESCRIPTION
### Description
OCI SDK had approximately 20 dependencies that can conflict with OpenSearch or another plugin that uses OCI SDK
Shading and relocating OCI SDK with 3rd party dependencies under org.opensearch.repositories.oci.sdk namespace

### Check List
- [NA] New functionality includes testing.
- [NA] New functionality has been documented.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-oci-object-storage/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
