### PR TITLE
Cache cleanup flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         sdk_version = "3.30.0"
-        jackson_version = "2.17.2"
+        jackson_version = "2.18.2"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ subprojects {
 
     ext {
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
-        sdk_version = "3.24.0"
-        jackson_version = "2.18.2"
+        sdk_version = "3.30.0"
+        jackson_version = "2.17.2"
     }
 
     repositories {

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
@@ -11,12 +11,17 @@
 
 package org.opensearch.repositories.oci;
 
+import static java.util.Collections.emptyMap;
+
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.common.collect.MapBuilder;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.LazyInitializable;
 import org.opensearch.repositories.oci.sdk.com.oracle.bmc.ClientConfiguration;
 import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageAsync;
 import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageAsyncClient;
@@ -27,7 +32,8 @@ public class OciObjectStorageService implements Closeable {
     /**
      * Dictionary of client instances. Client instances are built lazily from the latest settings.
      */
-    private final Map<String, ObjectStorageAsync> clientsCache = new HashMap<>();
+    private final AtomicReference<Map<Settings, LazyInitializable<ObjectStorageAsync, IOException>>>
+            clientsCache = new AtomicReference<>(emptyMap());
 
     /**
      * Attempts to retrieve a client from the cache. If the client does not exist it will be created
@@ -38,34 +44,34 @@ public class OciObjectStorageService implements Closeable {
      * @param clientName name of the client settings used to create the client
      * @return a cached client storage instance that can be used to manage objects (blobs)
      */
-    public synchronized ObjectStorageAsync client(
-            final String clientName, OciObjectStorageClientSettings clientSettings)
-            throws IOException {
+    public synchronized ObjectStorageAsync client(final Settings clientName) throws IOException {
 
-        ObjectStorageAsync client = clientsCache.get(clientName);
-        if (client == null) {
-            client = createClientAsync(clientName, clientSettings);
-            clientsCache.put(clientName, client);
+        final LazyInitializable<ObjectStorageAsync, IOException> lazyClient =
+                clientsCache.get().get(clientName);
+        if (lazyClient == null) {
+            log.warn("No client found for client name");
+            return null;
         }
-        return client;
+        return lazyClient.getOrCompute();
     }
 
     /**
      * Creates a client that can be used to manage OCI Object Storage objects. The client is
      * thread-safe.
      *
-     * @param clientName name of client settings to use, including secure settings
+     * @param clientCacheKey name of client settings to use, including secure settings
      * @param clientSettings name of client settings to use, including secure settings
      * @return a new client storage instance that can be used to manage objects (blobs)
      */
     static ObjectStorageAsync createClientAsync(
-            String clientName, OciObjectStorageClientSettings clientSettings) throws IOException {
+            Settings clientCacheKey, OciObjectStorageClientSettings clientSettings)
+            throws IOException {
         log.debug(
                 () ->
                         new ParameterizedMessage(
                                 "creating OCI object store client with client_name [{}], endpoint"
                                         + " [{}]",
-                                clientName,
+                                clientCacheKey,
                                 clientSettings.getEndpoint()));
 
         final ObjectStorageAsync objectStorageClient =
@@ -80,14 +86,67 @@ public class OciObjectStorageService implements Closeable {
         return objectStorageClient;
     }
 
+    /**
+     * Refreshes the client settings of existing and new clients. Will not clear the cache of other
+     * clients. Subsequent calls to {@code OciObjectStorageService#client} will return new clients
+     * constructed using the parameter settings.
+     *
+     * @param clientsSettings the new settings used for building clients for subsequent requests
+     */
+    public synchronized void refreshWithoutClearingCache(
+            Map<Settings, OciObjectStorageClientSettings> clientsSettings) {
+
+        // build the new lazy clients
+        final Map<Settings, LazyInitializable<ObjectStorageAsync, IOException>> oldClientCache =
+                clientsCache.get();
+        final MapBuilder<Settings, LazyInitializable<ObjectStorageAsync, IOException>>
+                newClientsCache = MapBuilder.newMapBuilder();
+
+        // replace or add new clients
+        newClientsCache.putAll(oldClientCache);
+        for (final Map.Entry<Settings, OciObjectStorageClientSettings> entry :
+                clientsSettings.entrySet()) {
+            final LazyInitializable<ObjectStorageAsync, IOException> previousClient =
+                    oldClientCache.get(entry.getKey());
+            newClientsCache.put(
+                    entry.getKey(),
+                    new LazyInitializable<>(
+                            () -> createClientAsync(entry.getKey(), entry.getValue())));
+            // we will release the previous client for this entry if existed
+            if (previousClient != null) {
+                previousClient.reset();
+            }
+        }
+        clientsCache.getAndSet(newClientsCache.immutableMap());
+    }
+
+    /**
+     * @param cacheKey
+     */
+    public synchronized void evictCache(Settings cacheKey) {
+
+        final Map<Settings, LazyInitializable<ObjectStorageAsync, IOException>> oldClientCache =
+                clientsCache.get();
+        final MapBuilder<Settings, LazyInitializable<ObjectStorageAsync, IOException>>
+                newClientsCache = MapBuilder.newMapBuilder();
+
+        for (Map.Entry<Settings, LazyInitializable<ObjectStorageAsync, IOException>> entry :
+                oldClientCache.entrySet()) {
+            if (!entry.getKey().equals(cacheKey)) {
+                newClientsCache.put(entry.getKey(), entry.getValue());
+            }
+        }
+        clientsCache.getAndSet(newClientsCache.immutableMap());
+    }
+
     @Override
     public void close() throws IOException {
         log.info("Shutting down all clients");
-        clientsCache.values().stream()
+        clientsCache.get().values().stream()
                 .forEach(
                         lazyClient -> {
                             try {
-                                lazyClient.close();
+                                lazyClient.getOrCompute().close();
                             } catch (Exception e) {
                                 log.error("unable to close client");
                             }

--- a/oci-repository-plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/oci-repository-plugin/src/main/plugin-metadata/plugin-security.policy
@@ -3,6 +3,8 @@ grant {
   // TODO: get these fixed in oci sdk
   // Required by Jersey
   permission java.lang.RuntimePermission "getClassLoader";
+  permission java.lang.RuntimePermission "setSecurityManager";
+  permission java.lang.RuntimePermission "createSecurityManager";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.util.PropertyPermission "*", "read,write";

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
@@ -34,7 +34,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.transport.Netty4ModulePlugin;
+import org.opensearch.transport.Netty4Plugin;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -62,7 +62,7 @@ public class OciObjectStoragePluginTests extends OpenSearchIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.unmodifiableCollection(
-                Lists.newArrayList(Netty4ModulePlugin.class, OciObjectStoragePlugin.class));
+                Lists.newArrayList(Netty4Plugin.class, OciObjectStoragePlugin.class));
     }
     /** ******************************* */
     @Test

--- a/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
+++ b/oci-repository-plugin/src/test/java/org/opensearch/repositories/oci/OciObjectStoragePluginTests.java
@@ -34,7 +34,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.transport.Netty4Plugin;
+import org.opensearch.transport.Netty4ModulePlugin;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -62,7 +62,7 @@ public class OciObjectStoragePluginTests extends OpenSearchIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.unmodifiableCollection(
-                Lists.newArrayList(Netty4Plugin.class, OciObjectStoragePlugin.class));
+                Lists.newArrayList(Netty4ModulePlugin.class, OciObjectStoragePlugin.class));
     }
     /** ******************************* */
     @Test


### PR DESCRIPTION
### Description
-  Security policies file refactored
- Cache key migrated from string to Settings object
- Cache cleanup in case of any exceptions
- OCI java SDK version updated to 3.30.0

### Related Issues
Enabled retries as a workaround for #57 
- Exceptions from object store client in case of 401 or 404 response code closes the jersey client
- Subsequent retries would cause IllegalState exception
- Thus remove oci client instance from cache to enable retries in case of any exception 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-oci-object-storage/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
