### PR TITLE
Fix the path to data files and class cast error while handling exception

### DIFF
--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobContainer.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobContainer.java
@@ -88,6 +88,6 @@ class OciObjectStorageBlobContainer extends AbstractBlobContainer {
 
     private String buildKey(String blobName) {
         assert blobName != null;
-        return path().add(blobName).buildAsString();
+        return path().buildAsString() + blobName;
     }
 }

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/SocketAccess.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/SocketAccess.java
@@ -34,7 +34,8 @@ public class SocketAccess {
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
-            throw (IOException) e.getCause();
+            if (e.getCause() instanceof IOException) throw (IOException) e.getCause();
+            throw new IOException(e.getCause());
         }
     }
 


### PR DESCRIPTION
### Description

- Fix the path to data files in OCI Object Storage
- Fix class cast error when trying to handle an exception

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-oci-object-storage/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
