### PR TITLE
Netty version update for CVE-2025-25193 CVE-2025-24970

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,9 @@ subprojects {
             force "org.apache.httpcomponents:httpclient:4.5.14"
             // Force spotless depending on newer version of guava due to CVE-2023-2976. Remove after spotless upgrades.
             force "com.google.guava:guava:32.1.2-jre"
-            // Force opensearch transport-netty4-client depending on newer version of netty-handler due to CVE-2023-34462.
+            // Force opensearch transport-netty4-client depending on newer version of netty-handler due to CVE-2025-25193, CVE-2025-24970.
             // Remove after upgrading the compiled opensearch version.
-            force "io.netty:netty-handler:4.1.94.Final"
+            force "io.netty:netty-handler:4.1.118.Final"
             force "org.bouncycastle:bcpkix-jdk15to18:1.78.1"
             force "org.bouncycastle:bcprov-jdk15to18:1.78.1"
             force "org.bouncycastle:bcutil-jdk15to18:1.78.1"


### PR DESCRIPTION
### Description
Netty version force to upgrade version to 4.1.118.Final

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/opensearch-oci-object-storage/issues/81

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-oci-object-storage/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
