### PR TITLE
Remove redundant retries for calls to OCI Object Store. (#95)

### DIFF
--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageClientSettings.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageClientSettings.java
@@ -163,18 +163,21 @@ public class OciObjectStorageClientSettings {
          * The SDK's "region code" is the internal enum's public region name.
          */
 
-        return SimpleAuthenticationDetailsProvider.builder()
-                .userId(userId)
-                .tenantId(tenantId)
-                .region(region)
-                .fingerprint(fingerprint)
-                .privateKeySupplier(privateKeySupplier)
-                .build();
+        return SocketAccess.doPrivilegedIOException(
+                () ->
+                        SimpleAuthenticationDetailsProvider.builder()
+                                .userId(userId)
+                                .tenantId(tenantId)
+                                .region(region)
+                                .fingerprint(fingerprint)
+                                .privateKeySupplier(privateKeySupplier)
+                                .build());
     }
 
     private static BasicAuthenticationDetailsProvider toAuthDetailsProvider() {
         try {
-            return InstancePrincipalsAuthenticationDetailsProvider.builder().build();
+            return SocketAccess.doPrivilegedIOException(
+                    () -> InstancePrincipalsAuthenticationDetailsProvider.builder().build());
         } catch (Exception ex) {
             log.error("Failure calling toAuthDetailsProvider", ex);
             throw ex;

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageService.java
@@ -19,14 +19,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.common.util.LazyInitializable;
-import org.opensearch.repositories.oci.sdk.com.oracle.bmc.ClientConfiguration;
 import org.opensearch.repositories.oci.sdk.com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import org.opensearch.repositories.oci.sdk.com.oracle.bmc.objectstorage.ObjectStorageClient;
 
 /** Service class to hold client instances */
 @Log4j2
 public class OciObjectStorageService implements Closeable {
-    private static final int READ_TIMEOUT_MILLIS = 120000;
 
     /**
      * Dictionary of client instances. Client instances are built lazily from the latest settings.
@@ -126,17 +124,10 @@ public class OciObjectStorageService implements Closeable {
 
         BasicAuthenticationDetailsProvider authenticationDetailsProvider =
                 clientSettings.getAuthenticationDetailsProvider();
-        ;
 
         final ObjectStorageClient objectStorageClient =
                 SocketAccess.doPrivilegedIOException(
-                        () ->
-                                ObjectStorageClient.builder()
-                                        .configuration(
-                                                ClientConfiguration.builder()
-                                                        .readTimeoutMillis(READ_TIMEOUT_MILLIS)
-                                                        .build())
-                                        .build(authenticationDetailsProvider));
+                        () -> new ObjectStorageClient(authenticationDetailsProvider));
 
         objectStorageClient.setEndpoint(clientSettings.getEndpoint());
 

--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/SocketAccess.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/SocketAccess.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import lombok.SneakyThrows;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.CheckedRunnable;
 
@@ -28,8 +29,8 @@ public class SocketAccess {
 
     private SocketAccess() {}
 
-    public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation)
-            throws IOException {
+    @SneakyThrows
+    public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) {
         SpecialPermission.check();
         try {
             return AccessController.doPrivileged(operation);
@@ -39,8 +40,8 @@ public class SocketAccess {
         }
     }
 
-    public static void doPrivilegedVoidIOException(CheckedRunnable<IOException> action)
-            throws IOException {
+    @SneakyThrows
+    public static void doPrivilegedVoidIOException(CheckedRunnable<IOException> action) {
         SpecialPermission.check();
         try {
             AccessController.doPrivileged(


### PR DESCRIPTION
### Description
* Removing legacy code that did redundant retries.
* Adding missing doPrivilegedIOException

### Check List
- [N/A ] New functionality includes testing.
- [N/A] New functionality has been documented.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-oci-object-storage/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
